### PR TITLE
Add "Match Case" and "Match Whole Word" options.

### DIFF
--- a/HighlightWordTagger.cs
+++ b/HighlightWordTagger.cs
@@ -178,7 +178,11 @@ namespace ProgressiveScroll
 
 			//Find the new spans
 			var findData = new FindData(currentWord.GetText(), currentWord.Snapshot);
-			findData.FindOptions = FindOptions.WholeWord | FindOptions.MatchCase;
+			findData.FindOptions = FindOptions.None;
+			if (Options.MatchCase)
+    			findData.FindOptions |= FindOptions.MatchCase;
+			if (Options.MatchWholeWord)
+    			findData.FindOptions |= FindOptions.WholeWord;
 
 			wordSpans.AddRange(TextSearchService.FindAll(findData));
 

--- a/HighlightWordTagger.cs
+++ b/HighlightWordTagger.cs
@@ -180,9 +180,9 @@ namespace ProgressiveScroll
 			var findData = new FindData(currentWord.GetText(), currentWord.Snapshot);
 			findData.FindOptions = FindOptions.None;
 			if (Options.MatchCase)
-    			findData.FindOptions |= FindOptions.MatchCase;
+				findData.FindOptions |= FindOptions.MatchCase;
 			if (Options.MatchWholeWord)
-    			findData.FindOptions |= FindOptions.WholeWord;
+				findData.FindOptions |= FindOptions.WholeWord;
 
 			wordSpans.AddRange(TextSearchService.FindAll(findData));
 

--- a/HighlightWordTaggerProvider.cs
+++ b/HighlightWordTaggerProvider.cs
@@ -13,7 +13,7 @@ using Microsoft.VisualStudio.Utilities;
 namespace ProgressiveScroll
 {
 	[Export(typeof (IViewTaggerProvider))]
-	[ContentType("code")]
+	[ContentType("text")]
 	[TextViewRole(PredefinedTextViewRoles.Document)]
 	[TagType(typeof (ClassificationTag))]
 	internal class HighlightWordTaggerProvider : IViewTaggerProvider

--- a/OptionsPage.cs
+++ b/OptionsPage.cs
@@ -20,6 +20,8 @@ namespace ProgressiveScroll
 		public const string SplitterEnabled = "SplitterEnabled";
 		public const string ErrorsEnabled = "ErrorsEnabled";
 		public const string AltHighlight = "AltHighlight";
+		public const string MatchCase = "MatchCase";
+		public const string MatchWholeWord = "MatchWholeWord";
 	}
 
 	[ClassInterface(ClassInterfaceType.AutoDual)]
@@ -34,6 +36,8 @@ namespace ProgressiveScroll
 		private bool _splitterEnabled = false;
 		private bool _errorsEnabled = false;
 		private bool _altHighlight = false;
+		private bool _matchCase = true;
+		private bool _matchWholeWord = true;
 
 		[Category("General")]
 		[DisplayName("Width")]
@@ -98,6 +102,24 @@ namespace ProgressiveScroll
 			set { _altHighlight = value; }
 		}
 
+		[Category("General")]
+		[DisplayName("Match Case")]
+		[Description("Only highlight case-sensitive matches for double-clicked text.")]
+		public bool MatchCase
+		{
+			get { return _matchCase; }
+			set { _matchCase = value; }
+		}
+
+		[Category("General")]
+		[DisplayName("Match Whole Word")]
+		[Description("Only highlight whole-word matches for double-clicked text.")]
+		public bool MatchWholeWord
+		{
+			get { return _matchWholeWord; }
+            set { _matchWholeWord = value; }
+		}
+
 		protected override void OnApply(PageApplyEventArgs e)
 		{
 			base.OnApply(e);
@@ -113,6 +135,8 @@ namespace ProgressiveScroll
 				Options.SplitterEnabled = _splitterEnabled;
 				Options.ErrorsEnabled = _errorsEnabled;
 				Options.AltHighlight = _altHighlight;
+				Options.MatchCase = _matchCase;
+				Options.MatchWholeWord = _matchWholeWord;
 
 				ProgressiveScroll.SettingsChanged();
 			}
@@ -134,6 +158,8 @@ namespace ProgressiveScroll
 		public static bool SplitterEnabled;
 		public static bool ErrorsEnabled;
 		public static bool AltHighlight;
+		public static bool MatchCase;
+		public static bool MatchWholeWord;
 
 		protected override void Initialize()
 		{
@@ -151,6 +177,8 @@ namespace ProgressiveScroll
 			SplitterEnabled = (bool)props.Item(OptionNames.SplitterEnabled).Value;
 			ErrorsEnabled = (bool)props.Item(OptionNames.ErrorsEnabled).Value;
 			AltHighlight = (bool)props.Item(OptionNames.AltHighlight).Value;
+			MatchCase = (bool)props.Item(OptionNames.MatchCase).Value;
+			MatchWholeWord = (bool)props.Item(OptionNames.MatchWholeWord).Value;
 		}
 	}
 }

--- a/OptionsPage.cs
+++ b/OptionsPage.cs
@@ -117,7 +117,7 @@ namespace ProgressiveScroll
 		public bool MatchWholeWord
 		{
 			get { return _matchWholeWord; }
-            set { _matchWholeWord = value; }
+			set { _matchWholeWord = value; }
 		}
 
 		protected override void OnApply(PageApplyEventArgs e)

--- a/ProgressiveScrollFactory.cs
+++ b/ProgressiveScrollFactory.cs
@@ -24,7 +24,7 @@ namespace ProgressiveScroll
 	[Name(ProgressiveScroll.MarginName)]
 	[Order(After = PredefinedMarginNames.VerticalScrollBar)]
 	[MarginContainer(PredefinedMarginNames.VerticalScrollBarContainer)]
-	[ContentType("code")]
+	[ContentType("text")]
 	[TextViewRole(PredefinedTextViewRoles.Document)]
 	internal sealed class ProgressiveScrollFactory : IWpfTextViewMarginProvider
 	{


### PR DESCRIPTION
I've added a couple of options that allow the user to customize the `FindOptions` that are used for finding matches for a double-clicked word / string. By default, the previous / original settings are used (`MatchCase` and `WholeWord` are both true), but they can now be toggled via checkboxes in the ProgressiveScroll settings window.

I also broadened the scope of files for which ProgressiveScroll is activated, to all `text` files (not just `code` file types).

I've found both these changes useful, and I thought other users might too, hence this PR. Let me know what you think! 😁